### PR TITLE
Allowing CORS for localhost

### DIFF
--- a/talelio_backend/config/config.py
+++ b/talelio_backend/config/config.py
@@ -12,4 +12,6 @@ class Development(Config):
 
 
 class Production(Config):
-    CORS_ORIGIN_WHITELIST = {'origins': ['https://www.talel.io', 'https://talel.io']}
+    CORS_ORIGIN_WHITELIST = {
+        'origins': ['https://www.talel.io', 'https://talel.io', 'http://localhost:3000']
+    }


### PR DESCRIPTION
This PR is for temporarily allowing CORS for localhost:3000 while developing on the talel.io frontend.