### PR TITLE
Returning refresh token in httpOnly cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,6 @@ https://api.talel.io/v1/accounts/login \
 
 {
   "access_token": "eyJ0eX...eyJ1c2...2U4WpJ",
-  "refresh_token": "eyJ0eX...eyJ1c2...Z4XTA0"
 }
 ```
 
@@ -325,8 +324,7 @@ https://api.talel.io/v1/accounts/login \
 ```shell
 curl -X POST \
 https://api.talel.io/v1/accounts/token \
--H "Content-Type: application/json" \
--d '{"refresh_token": <str>}'
+--cookie "refresh_token=<token>"
 ```
 
 ### Success Response
@@ -346,19 +344,7 @@ https://api.talel.io/v1/accounts/token \
 
 {
   "error": {
-    "message": "Missing request body",
-    "status": 400,
-    "type": "Bad Request"
-  }
-}
-```
-
-```shell
-400: BAD REQUEST
-
-{
-  "error": {
-    "message": "Expected '<key>' key",
+    "message": "<pyjwt error>",
     "status": 400,
     "type": "Bad Request"
   }

--- a/talelio_backend/tests/e2e/conftest.py
+++ b/talelio_backend/tests/e2e/conftest.py
@@ -1,8 +1,8 @@
+from re import match
 from typing import Dict, Generator
 from unittest.mock import patch
 
 import pytest
-from flask import json
 from flask.testing import FlaskClient
 
 from talelio_backend.core.db import engine
@@ -39,6 +39,11 @@ def populate_db_project(api_server: FlaskClient, authorization_header: Dict[str,
 @pytest.fixture(scope='class')
 def login_user_talel(api_server: FlaskClient) -> Dict[str, str]:
     res = api_server.post(f'{ACCOUNTS_BASE_URL}/login', json=talel_login_data)
-    res_data = json.loads(res.data)
 
-    return res_data
+    cookie_header = res.headers['Set-Cookie'].split('=')[1]
+    cookie_header_match = match('^.+?(?=;)', cookie_header)
+
+    if cookie_header_match:
+        refresh_token = cookie_header_match.group(0)
+
+    return {'refresh_token': refresh_token}

--- a/talelio_backend/tests/e2e/helpers.py
+++ b/talelio_backend/tests/e2e/helpers.py
@@ -25,11 +25,14 @@ class RequestHelper:
     def login_request(self, login_data: Union[Dict[str, str], None] = None) -> Response:
         return self.api.post(f'{ACCOUNTS_BASE_URL}/login', json=login_data)  # type: ignore
 
-    def new_access_token_request(self,
-                                 refresh_token_data: Union[Dict[str, str],
-                                                           None] = None) -> Response:
+    def new_access_token_request(self, refresh_token_data: Union[str, None] = None) -> Response:
+        self.api.cookie_jar.clear_session_cookies()  # type: ignore
+
+        if refresh_token_data:
+            self.api.set_cookie('', 'refresh_token', refresh_token_data)  # type: ignore
+
         return self.api.post(  # type: ignore
-            f'{ACCOUNTS_BASE_URL}/token', json=refresh_token_data)
+            f'{ACCOUNTS_BASE_URL}/token')
 
     def logout_request(self, authentication_header: Dict[str, str]) -> Response:
         return self.api.post(  # type: ignore

--- a/talelio_backend/tests/e2e/test_account_api.py
+++ b/talelio_backend/tests/e2e/test_account_api.py
@@ -129,7 +129,7 @@ class TestLogin(RequestHelper):
 
         assert res.status_code == 200
         assert res_data['access_token']
-        assert res_data['refresh_token']
+        assert res.headers['Set-Cookie']
 
     def test_access_token_expires_30_min_after_login(self) -> None:
         res_login = self.login_request(talel_login_data)
@@ -189,56 +189,49 @@ class TestNewAccessToken(RequestHelper):
     def test_valid_refresh_token_can_generate_new_access_token(
             self, login_user_talel: Dict[str, str]) -> None:
         refresh_token = login_user_talel['refresh_token']
-        refresh_token_data = {'refresh_token': refresh_token}
 
-        res = self.new_access_token_request(refresh_token_data)
+        res = self.new_access_token_request(refresh_token)
         res_data = json.loads(res.data)
 
         assert res.status_code == 200
         assert res_data['access_token']
 
-    def test_invalid_refresh_token_cannot_generate_new_access_token(self) -> None:
+    def test_cannot_generate_new_access_token_with_invalid_refresh_token_for_user(self) -> None:
         invalid_refresh_token = Authentication.generate_token({
             'user_id': INITIAL_USER_ID,
             'username': USERNAME_TALEL
         })
-        invalid_refresh_token_data = {'refresh_token': invalid_refresh_token}
 
-        res = self.new_access_token_request(invalid_refresh_token_data)
+        res = self.new_access_token_request(invalid_refresh_token)
         res_data = json.loads(res.data)
 
         assert res.status_code == 401
         assert res_data['error'][
             'message'] == 'Provided refresh token not matching stored refresh token'
 
-    def test_cannot_generate_access_token_for_user_with_no_stored_refresh_token(self) -> None:
+    def test_cannot_generate_new_access_token_with_invalid_refresh_token_signature(
+            self, login_user_talel: Dict[str, str]) -> None:
+        refresh_token = login_user_talel['refresh_token'] + 'ABC'
+        res = self.new_access_token_request(refresh_token)
+
+        assert res.status_code == 400
+
+    def test_cannot_generate_new_access_token_for_user_with_no_stored_refresh_token(self) -> None:
         invalid_refresh_token = Authentication.generate_token({
             'user_id': INITIAL_USER_ID + 1986,
             'username': USERNAME_TALEL
         })
-        invalid_refresh_token_data = {'refresh_token': invalid_refresh_token}
 
-        res = self.new_access_token_request(invalid_refresh_token_data)
+        res = self.new_access_token_request(invalid_refresh_token)
         res_data = json.loads(res.data)
 
         assert res.status_code == 401
         assert res_data['error']['message'] == 'No stored refresh token for user'
 
     def test_cannot_generate_new_access_token_when_missing_refresh_token(self) -> None:
-        invalid_refresh_token_data = {'invalid_key': ''}
-
-        res = self.new_access_token_request(invalid_refresh_token_data)
-        res_data = json.loads(res.data)
-
-        assert res.status_code == 400
-        assert res_data['error']['message'] == "Expected 'refresh_token' key"
-
-    def test_cannot_generate_new_access_token_with_missing_request_body(self) -> None:
         res = self.new_access_token_request()
-        res_data = json.loads(res.data)
 
         assert res.status_code == 400
-        assert res_data['error']['message'] == 'Missing request body'
 
 
 @pytest.mark.usefixtures('populate_db_account', 'login_user_talel')

--- a/talelio_backend/tests/e2e/test_account_api.py
+++ b/talelio_backend/tests/e2e/test_account_api.py
@@ -211,7 +211,7 @@ class TestNewAccessToken(RequestHelper):
 
     def test_cannot_generate_new_access_token_with_invalid_refresh_token_signature(
             self, login_user_talel: Dict[str, str]) -> None:
-        refresh_token = login_user_talel['refresh_token'] + 'ABC'
+        refresh_token = login_user_talel['refresh_token'] + 'TALEL'
         res = self.new_access_token_request(refresh_token)
 
         assert res.status_code == 400


### PR DESCRIPTION
This PR makes changes so that the refresh token is returned in a httpOnly cookie instead of in the response message.