### PR TITLE
Allowing credentials in CORS settings

### DIFF
--- a/talelio_backend/config/config.py
+++ b/talelio_backend/config/config.py
@@ -12,6 +12,4 @@ class Development(Config):
 
 
 class Production(Config):
-    CORS_ORIGIN_WHITELIST = {
-        'origins': ['https://www.talel.io', 'https://talel.io', 'http://localhost:3000']
-    }
+    CORS_ORIGIN_WHITELIST = {'origins': ['https://www.talel.io', 'https://talel.io']}

--- a/talelio_backend/core/__init__.py
+++ b/talelio_backend/core/__init__.py
@@ -23,7 +23,7 @@ def create_app() -> Flask:
     app.register_blueprint(projects_v1, url_prefix='/v1/projects')
     app.register_blueprint(users_v1, url_prefix='/v1/users')
 
-    CORS(app, resources={r'/*': app.config['CORS_ORIGIN_WHITELIST']})
+    CORS(app, resources={r'/*': app.config['CORS_ORIGIN_WHITELIST']}, supports_credentials=True)
     error_handlers(app)
 
     return app


### PR DESCRIPTION
This PR allows credentials in the CORS settings and removes localhost from CORS origin production whitelist.