### PR TITLE
Including attributes list extension for Markdown

### DIFF
--- a/talelio_backend/app_article/domain/article_model.py
+++ b/talelio_backend/app_article/domain/article_model.py
@@ -15,7 +15,9 @@ class Article:
         self.html = ''
         self.featured_image = featured_image
 
-        self.markdown = Markdown(extensions=['fenced_code', ImageSrcExtractorExtension()])
+        self.markdown = Markdown(
+            extensions=['attr_list', 'fenced_code',
+                        ImageSrcExtractorExtension()])
 
     @property
     def convert_body_to_html(self) -> None:


### PR DESCRIPTION
This PR makes it possible to add custom attributes to HTML elements when writing Markdown.