### PR TITLE
Add articles pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,10 @@ The bucket for database backups have all public access blocked and only the EC2 
 
 ### Articles
 
-| HTTP Method | Description                                                 | Resource                                 | Success Code | Failure Code |
-|-------------|-------------------------------------------------------------|------------------------------------------|--------------|--------------|
-| GET         | [List articles for a user](#get---list-articles-for-a-user) | /\<version\>/users/\<username\>/articles | 200          | 400          |
+| HTTP Method | Description                                                 | Resource                                          | Success Code | Failure Code |
+|-------------|-------------------------------------------------------------|---------------------------------------------------|--------------|--------------|
+| GET         | [List articles for a user](#get---list-articles-for-a-user) | /\<version\>/users/\<username\>/articles          | 200          | 400          |
+| GET         | [Article for a user](#get---article-for-a-user)             | /\<version\>/users/\<username\>/articles/\<slug/> |              |              |
 
 <details>
 
@@ -170,9 +171,56 @@ _*Response Body*_
 
 </details>
 
+<details>
 
+<summary>GET - Article for a user</summary>
 
+#### Request
 
+```shell
+```
+
+#### Success Response
+
+_*Response Body*_
+
+```shell
+200: OK
+
+{
+  "meta": {
+    "adjacent_articles": {
+      "next": {
+        "title": "Next Article",
+        "slug": "next-article"
+      },
+      "prev": {
+        "title": "Previous Article",
+        "slug": "previous-article"
+      }
+    }
+  },
+  "article": {
+    "id": 2,
+    "created_at": "1986-06-05T00:00:00.000000",
+    "updated_at": null,
+    "title": "Hello World Article",
+    "slug": "hello-world-article",
+    "body": "# Hello World",
+    "meta_description": "An article published on talel.io",
+    "html": "<h1>Hello World</h1>",
+    "featured_image": "/url/to/featured_image.jpg",
+    "url": "https://www.talel.io/articles/hello-world-article"
+  }
+}
+```
+
+#### Error Response
+
+```shell
+```
+
+</details>
 
 [^1]: [S3 pricing.](https://aws.amazon.com/s3/pricing/?nc=sn&loc=4)
 ---

--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ The bucket for database backups have all public access blocked and only the EC2 
 
 ### Articles
 
-| HTTP Method | Description                                                 | Resource | Success Code | Failure Code |
-|-------------|-------------------------------------------------------------|----------|--------------|--------------|
-| GET         | [List articles for a user](#get---list-articles-for-a-user) |          | 200          |              |
+| HTTP Method | Description                                                 | Resource                                 | Success Code | Failure Code |
+|-------------|-------------------------------------------------------------|------------------------------------------|--------------|--------------|
+| GET         | [List articles for a user](#get---list-articles-for-a-user) | /\<version\>/users/\<username\>/articles | 200          | 400          |
 
 <details>
 
@@ -99,6 +99,13 @@ The bucket for database backups have all public access blocked and only the EC2 
 <br/>
 
 Pagination is achieved with the `?page=<number>&limit=<number>` query parameters.
+
+#### Request
+
+```shell
+curl -X GET \
+https://api.talel.io/v1/users/<username>/articles
+```
 
 #### Success Response
 
@@ -155,18 +162,6 @@ _*Response Body*_
 {
    "error": {
       "message": "Expected numeric query parameters",
-      "status": 400,
-      "type": "Bad Request"
-   }
-}
-```
-
-```shell
-400: BAD REQUEST
-
-{
-   "error": {
-      "message": "User '<username>' does not exist",
       "status": 400,
       "type": "Bad Request"
    }

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
     - [Database Schema Migration](#database-schema-migration)
     - [Backup](#backup)
   - [AWS S3 (Simple Storage Service)](#aws-s3-simple-storage-service)
+- [API](#api)
+  - [Resources](#resources)
+    - [Articles](#articles)
 
 # Authentication
 
@@ -77,6 +80,49 @@ Both the bucket for user content and test content have their policy permissions 
 #### Private Buckets
 
 The bucket for database backups have all public access blocked and only the EC2 instance is allowed full access via the `IAM Role` attached to the instance.
+
+# API
+
+## Resources
+
+- [Articles](#articles)
+
+### Articles
+
+| HTTP Method | Description                                                 | Resource | Success Code | Failure Code |
+|-------------|-------------------------------------------------------------|----------|--------------|--------------|
+| GET         | [List articles for a user](#get---list-articles-for-a-user) |          |              |              |
+
+<details>
+
+<summary>GET - List articles for a user</summary>
+
+#### Success Response
+
+```shell
+200: OK
+
+{
+   "items": [
+      {
+         "id": 1,
+         "user_id": 1,
+         "username": "",
+         "created_at": "",
+         "updated_at": null,
+         "title": "",
+         "slug": "",
+         "body": "",
+         "meta_description": "",
+         "html": "",
+         "featured_image": "",
+         "url": ""
+      }
+   ]
+}
+```
+
+</details>
 
 
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
     - [Database Schema Migration](#database-schema-migration)
     - [Backup](#backup)
   - [AWS S3 (Simple Storage Service)](#aws-s3-simple-storage-service)
-- [API](#api)
+- [REST API](#rest-api)
   - [Resources](#resources)
     - [Articles](#articles)
 
@@ -81,7 +81,7 @@ Both the bucket for user content and test content have their policy permissions 
 
 The bucket for database backups have all public access blocked and only the EC2 instance is allowed full access via the `IAM Role` attached to the instance.
 
-# API
+# REST API
 
 ## Resources
 
@@ -91,34 +91,85 @@ The bucket for database backups have all public access blocked and only the EC2 
 
 | HTTP Method | Description                                                 | Resource | Success Code | Failure Code |
 |-------------|-------------------------------------------------------------|----------|--------------|--------------|
-| GET         | [List articles for a user](#get---list-articles-for-a-user) |          |              |              |
+| GET         | [List articles for a user](#get---list-articles-for-a-user) |          | 200          |              |
 
 <details>
 
 <summary>GET - List articles for a user</summary>
+<br/>
+
+Pagination is achieved with the `?page=<number>&limit=<number>` query parameters.
 
 #### Success Response
+
+_*Link Header*_
+
+URLs for the next and previous pagination values.
+
+```shell
+Link: </users/<username>/articles?page=3&limit=10>; rel="next",
+</users/<username>/articles?page=1&limit=10>; rel="prev"
+```
+
+_*X-Total-Count Header*_
+
+Total number of articles for the queried user.
+
+```shell
+X-Total-Count: 100
+```
+
+_*Response Body*_
 
 ```shell
 200: OK
 
 {
-   "items": [
+   "user": {
+      "username": "talel",
+      "location": "Berlin",
+      "avatar_url": "/url/to/avatar.jpg"
+   },
+   "articles": [
       {
          "id": 1,
-         "user_id": 1,
-         "username": "",
-         "created_at": "",
+         "created_at": "1986-06-05T00:00:00.000000",
          "updated_at": null,
-         "title": "",
-         "slug": "",
-         "body": "",
-         "meta_description": "",
-         "html": "",
-         "featured_image": "",
-         "url": ""
+         "title": "Hello World Article",
+         "slug": "hello-world-article",
+         "body": "# Hello World",
+         "meta_description": "An article published on talel.io",
+         "html": "<h1>Hello World</h1>",
+         "featured_image": "/url/to/featured_image.jpg",
+         "url": "https://www.talel.io/articles/hello-world-article"
       }
    ]
+}
+```
+
+#### Error Response
+
+```shell
+400: BAD REQUEST
+
+{
+   "error": {
+      "message": "Expected numeric query parameters",
+      "status": 400,
+      "type": "Bad Request"
+   }
+}
+```
+
+```shell
+400: BAD REQUEST
+
+{
+   "error": {
+      "message": "User '<username>' does not exist",
+      "status": 400,
+      "type": "Bad Request"
+   }
 }
 ```
 

--- a/talelio_backend/app_article/data/article_repository.py
+++ b/talelio_backend/app_article/data/article_repository.py
@@ -1,5 +1,9 @@
 from typing import Any
 
+from sqlalchemy.orm import contains_eager
+from sqlalchemy.sql import text
+from sqlalchemy.sql.expression import func
+
 from talelio_backend.shared.data.repository import BaseRepository
 
 
@@ -7,6 +11,20 @@ class ArticleRepository(BaseRepository):
 
     def get(self, model: Any, **kwargs: Any) -> Any:
         if 'slug' in kwargs:
-            return self.session.query(model).filter_by(slug=kwargs.get('slug')).first()
+            query_res = self.session.query(model).filter_by(slug=kwargs.get('slug')).first()
+        if 'username' in kwargs:
+            username = kwargs.get('username')
+            limit = kwargs.get('limit')
+            offset = kwargs.get('offset')
 
-        return self.session.query(model).order_by(model.id.desc()).first()
+            query = self.session.query(
+                model,
+                func.count(model.articles).over().label('total_articles_count'))
+            query = query.filter_by(username=username)
+            query = query.join(model.articles).order_by(text('article.created_at desc'))
+            query = query.limit(limit).offset(offset)
+            query_res = query.options(contains_eager(model.articles)).populate_existing().all()
+        else:
+            query_res = self.session.query(model).order_by(model.id.desc()).first()
+
+        return query_res

--- a/talelio_backend/app_article/domain/article_model.py
+++ b/talelio_backend/app_article/domain/article_model.py
@@ -4,7 +4,7 @@ from typing import Optional
 from markdown import Markdown
 
 from talelio_backend.shared.markdown_extensions import ImageSrcExtractorExtension
-from talelio_backend.shared.utils import generate_slug
+from talelio_backend.shared.utils.slug import generate_slug
 
 
 class Article:

--- a/talelio_backend/app_article/use_cases/get_articles.py
+++ b/talelio_backend/app_article/use_cases/get_articles.py
@@ -1,19 +1,45 @@
-from typing import List
+from typing import Dict, Optional, Union
 
 from talelio_backend.app_article.domain.article_model import Article
 from talelio_backend.app_user.domain.user_model import User
 from talelio_backend.core.exceptions import UserError
 from talelio_backend.data.uow import UnitOfWork
+from talelio_backend.shared.utils.pagination import Pagination
 
 
-def get_user_articles(uow: UnitOfWork, username: str) -> List[Article]:
+def get_user_with_articles(
+        uow: UnitOfWork, username: str, page: Optional[Union[int, None]],
+        limit: Optional[Union[int, None]]) -> Dict[str, Union[User, int, str, None]]:
     with uow:
-        user_record = uow.user.get(User, username=username)
+        page = page if page and page != 0 else 1
+        limit = limit if limit and limit != 0 else 10
 
-        if user_record is None:
+        offset = Pagination.calculate_offset(page, limit)
+
+        user_record = uow.user.get(User, username=username, limit=limit, offset=offset)
+
+        # TODO: Fix error getting raised for also out of range
+        if len(user_record) == 0:
             raise UserError(f"User '{username}' does not exist")
 
-        return user_record.articles
+        user_record = user_record[0]._asdict()
+        user = user_record['User']
+
+        total_articles_count: int = user_record['total_articles_count']
+        pages = Pagination.total_pages(total_articles_count, limit)
+        last_page = page == pages
+
+        next_link = (f'/users/{username}/articles?page={page + 1}&limit={limit}'
+                     if not last_page else None)
+        prev_link = (f'/users/{username}/articles?page={page - 1}&limit={limit}'
+                     if page - 1 != 0 else None)
+
+        return {
+            'user': user,
+            'total_articles_count': total_articles_count,
+            'next_link': next_link,
+            'prev_link': prev_link
+        }
 
 
 def get_article(uow: UnitOfWork, slug: str) -> Article:

--- a/talelio_backend/app_article/use_cases/get_articles.py
+++ b/talelio_backend/app_article/use_cases/get_articles.py
@@ -2,14 +2,13 @@ from typing import Dict, Optional, Union
 
 from talelio_backend.app_article.domain.article_model import Article
 from talelio_backend.app_user.domain.user_model import User
-from talelio_backend.core.exceptions import UserError
 from talelio_backend.data.uow import UnitOfWork
 from talelio_backend.shared.utils.pagination import Pagination
 
 
 def get_user_with_articles(
         uow: UnitOfWork, username: str, page: Optional[Union[int, None]],
-        limit: Optional[Union[int, None]]) -> Dict[str, Union[User, int, str, None]]:
+        limit: Optional[Union[int, None]]) -> Union[Dict, Dict[str, Union[User, int, str, None]]]:
     with uow:
         page = page if page and page != 0 else 1
         limit = limit if limit and limit != 0 else 10
@@ -18,14 +17,14 @@ def get_user_with_articles(
 
         user_record = uow.user.get(User, username=username, limit=limit, offset=offset)
 
-        # TODO: Fix error getting raised for also out of range
         if len(user_record) == 0:
-            raise UserError(f"User '{username}' does not exist")
+            return {}
 
         user_record = user_record[0]._asdict()
-        user = user_record['User']
 
-        total_articles_count: int = user_record['total_articles_count']
+        user = user_record['User']
+        total_articles_count = user_record['total_articles_count']
+
         pages = Pagination.total_pages(total_articles_count, limit)
         last_page = page == pages
 

--- a/talelio_backend/app_article/use_cases/get_articles.py
+++ b/talelio_backend/app_article/use_cases/get_articles.py
@@ -6,7 +6,7 @@ from talelio_backend.data.uow import UnitOfWork
 from talelio_backend.shared.utils.pagination import Pagination
 
 
-def get_user_with_articles(
+def get_articles_for_user(
         uow: UnitOfWork, username: str, page: Optional[Union[int, None]],
         limit: Optional[Union[int, None]]) -> Union[Dict, Dict[str, Union[User, int, str, None]]]:
     with uow:
@@ -15,15 +15,18 @@ def get_user_with_articles(
 
         offset = Pagination.calculate_offset(page, limit)
 
-        user_record = uow.user.get(User, username=username, limit=limit, offset=offset)
+        user_articles_record = uow.articles.get(User,
+                                                username=username,
+                                                limit=limit,
+                                                offset=offset)
 
-        if len(user_record) == 0:
+        if len(user_articles_record) == 0:
             return {}
 
-        user_record = user_record[0]._asdict()
+        user_articles_record = user_articles_record[0]._asdict()
 
-        user = user_record['User']
-        total_articles_count = user_record['total_articles_count']
+        user = user_articles_record['User']
+        total_articles_count = user_articles_record['total_articles_count']
 
         pages = Pagination.total_pages(total_articles_count, limit)
         last_page = page == pages

--- a/talelio_backend/app_user/data/user_repository.py
+++ b/talelio_backend/app_user/data/user_repository.py
@@ -1,9 +1,5 @@
 from typing import Any
 
-from sqlalchemy.orm import contains_eager
-from sqlalchemy.sql import text
-from sqlalchemy.sql.expression import func
-
 from talelio_backend.shared.data.repository import BaseRepository
 
 
@@ -15,16 +11,6 @@ class UserRepository(BaseRepository):
         if 'id' in kwargs:
             query = self.session.query(model).filter_by(id=kwargs.get('id')).first()
         if 'username' in kwargs:
-            username = kwargs.get('username')
-            limit = kwargs.get('limit')
-            offset = kwargs.get('offset')
-
-            query = self.session.query(
-                model,
-                func.count(model.articles).over().label('total_articles_count'))
-            query = query.filter_by(username=username)
-            query = query.join(model.articles).order_by(text('article.created_at desc'))
-            query = query.limit(limit).offset(offset)
-            query = query.options(contains_eager(model.articles)).populate_existing().all()
+            query = self.session.query(model).filter_by(username=kwargs.get('username')).first()
 
         return query

--- a/talelio_backend/app_user/data/user_repository.py
+++ b/talelio_backend/app_user/data/user_repository.py
@@ -1,16 +1,30 @@
 from typing import Any
 
+from sqlalchemy.orm import contains_eager
+from sqlalchemy.sql import text
+from sqlalchemy.sql.expression import func
+
 from talelio_backend.shared.data.repository import BaseRepository
 
 
 class UserRepository(BaseRepository):
 
     def get(self, model: Any, **kwargs: Any) -> Any:
-        user: Any
+        query: Any
 
         if 'id' in kwargs:
-            user = self.session.query(model).filter_by(id=kwargs.get('id')).first()
+            query = self.session.query(model).filter_by(id=kwargs.get('id')).first()
         if 'username' in kwargs:
-            user = self.session.query(model).filter_by(username=kwargs.get('username')).first()
+            username = kwargs.get('username')
+            limit = kwargs.get('limit')
+            offset = kwargs.get('offset')
 
-        return user
+            query = self.session.query(
+                model,
+                func.count(model.articles).over().label('total_articles_count'))
+            query = query.filter_by(username=username)
+            query = query.join(model.articles).order_by(text('article.created_at desc'))
+            query = query.limit(limit).offset(offset)
+            query = query.options(contains_eager(model.articles)).populate_existing().all()
+
+        return query

--- a/talelio_backend/app_user/use_cases/authenticate_user.py
+++ b/talelio_backend/app_user/use_cases/authenticate_user.py
@@ -3,7 +3,7 @@ from talelio_backend.core.exceptions import AccountError, TokenError
 from talelio_backend.data.uow import UnitOfWork
 from talelio_backend.identity_and_access.authentication import Authentication
 from talelio_backend.identity_and_access.token_store import TokenStore
-from talelio_backend.shared.utils import generate_time_from_now
+from talelio_backend.shared.utils.time import generate_time_from_now
 
 
 def generate_access_token(user_id: int, username: str) -> str:

--- a/talelio_backend/interfaces/api/articles/article_controller.py
+++ b/talelio_backend/interfaces/api/articles/article_controller.py
@@ -36,7 +36,7 @@ def create_article_endpoint() -> Tuple[Response, int]:
             meta_description = request.json['meta_description']
 
             # Allows for an optional featured_image request parameter
-            # withour raising the KeyError exception if not provided.
+            # without raising the KeyError exception if not provided.
             featured_image = str(request.json.get('featured_image') or '')
 
             created_article = create_article(uow, user_id, title, body, meta_description,

--- a/talelio_backend/interfaces/api/users/user_controller.py
+++ b/talelio_backend/interfaces/api/users/user_controller.py
@@ -3,7 +3,7 @@ from typing import Tuple, Union, cast
 
 from flask import Blueprint, Response, jsonify, request
 
-from talelio_backend.app_article.use_cases.get_articles import get_user_with_articles
+from talelio_backend.app_article.use_cases.get_articles import get_articles_for_user
 from talelio_backend.app_project.use_cases.get_projects import get_user_projects
 from talelio_backend.app_user.domain.user_model import User
 from talelio_backend.core.exceptions import UserError
@@ -26,14 +26,14 @@ def get_user_articles_endpoint(username: str) -> Union[Tuple[Response, int], Res
         page = int(page_param) if page_param else None
         limit = int(limit_param) if limit_param else None
 
-        user_with_articles = get_user_with_articles(uow, username, page, limit)
+        articles_for_user = get_articles_for_user(uow, username, page, limit)
 
-        if not 'user' in user_with_articles:
-            return jsonify(user_with_articles), 200
+        if not 'user' in articles_for_user:
+            return jsonify(articles_for_user), 200
 
-        user = cast(User, user_with_articles['user'])
-        next_link = cast(Union[str, None], user_with_articles['next_link'])
-        prev_link = cast(Union[str, None], user_with_articles['prev_link'])
+        user = cast(User, articles_for_user['user'])
+        next_link = cast(Union[str, None], articles_for_user['next_link'])
+        prev_link = cast(Union[str, None], articles_for_user['prev_link'])
         next_rel = 'rel="next"'
         prev_rel = 'rel="prev"'
 
@@ -44,7 +44,7 @@ def get_user_articles_endpoint(username: str) -> Union[Tuple[Response, int], Res
         })
 
         res = Response(json.dumps(res_body), status=200, mimetype='application/json')
-        res.headers['X-Total-Count'] = cast(int, user_with_articles['total_articles_count'])
+        res.headers['X-Total-Count'] = cast(int, articles_for_user['total_articles_count'])
         res.headers['Link'] = (f'{"<" + next_link + ">; " + next_rel if next_link else ""}'
                                f'{", " if prev_link and next_link else ""}'
                                f' {"<" + prev_link + ">; " + prev_rel if prev_link else ""}')

--- a/talelio_backend/interfaces/api/users/user_controller.py
+++ b/talelio_backend/interfaces/api/users/user_controller.py
@@ -1,27 +1,55 @@
-from typing import Tuple
+import json
+from typing import Tuple, Union, cast
 
-from flask import Blueprint, Response, jsonify
+from flask import Blueprint, Response, jsonify, request
 
-from talelio_backend.app_article.use_cases.get_articles import get_user_articles
+from talelio_backend.app_article.use_cases.get_articles import get_user_with_articles
 from talelio_backend.app_project.use_cases.get_projects import get_user_projects
+from talelio_backend.app_user.domain.user_model import User
 from talelio_backend.core.exceptions import UserError
 from talelio_backend.data.uow import UnitOfWork
-from talelio_backend.interfaces.api.articles.article_serializer import ArticleSchema
 from talelio_backend.interfaces.api.errors import APIError
 from talelio_backend.interfaces.api.projects.project_serializer import ProjectSchema
+from talelio_backend.interfaces.api.users.user_serializers import UserArticlesSchema
 
 users_v1 = Blueprint('users_v1', __name__)
 
 
 @users_v1.get('/<string:username>/articles')
-def get_user_articles_endpoint(username: str) -> Tuple[Response, int]:
+def get_user_articles_endpoint(username: str) -> Response:
     try:
         uow = UnitOfWork()
 
-        user_articles = get_user_articles(uow, username)
-        res_body = ArticleSchema(many=True).dump(user_articles)
+        page_param = request.args.get('page')
+        limit_param = request.args.get('limit')
 
-        return jsonify(res_body), 200
+        page = int(page_param) if page_param else None
+        limit = int(limit_param) if limit_param else None
+
+        user_with_articles = get_user_with_articles(uow, username, page, limit)
+
+        user = cast(User, user_with_articles['user'])
+        next_link = cast(Union[str, None], user_with_articles['next_link'])
+        prev_link = cast(Union[str, None], user_with_articles['prev_link'])
+        next_rel = 'rel="next"'
+        prev_rel = 'rel="prev"'
+
+        # TODO: Resolve type error
+        res_body = UserArticlesSchema().dump({
+            'user': user,
+            'articles': user.articles
+        }  # type: ignore
+                                             )
+
+        res = Response(json.dumps(res_body), status=200, mimetype='application/json')
+        res.headers['X-Total-Count'] = cast(int, user_with_articles['total_articles_count'])
+        res.headers['Link'] = (f'{"<" + next_link + ">; " + next_rel if next_link else ""}'
+                               f'{", " if prev_link and next_link else ""}'
+                               f' {"<" + prev_link + ">; " + prev_rel if prev_link else ""}')
+
+        return res
+    except ValueError as error:
+        raise APIError('Expected numeric query parameters', 400) from error
     except UserError as error:
         raise APIError(str(error), 400) from error
 

--- a/talelio_backend/interfaces/api/users/user_serializers.py
+++ b/talelio_backend/interfaces/api/users/user_serializers.py
@@ -1,5 +1,7 @@
 from marshmallow import Schema, fields
 
+from talelio_backend.interfaces.api.articles.article_serializer import ArticleSchema
+
 
 class UserSchema(Schema):
     id = fields.Int()
@@ -9,3 +11,8 @@ class UserSchema(Schema):
     username = fields.Str()
     location = fields.Str()
     avatar_url = fields.Str()
+
+
+class UserArticlesSchema(Schema):
+    user = fields.Nested(UserSchema(only=['username', 'location', 'avatar_url']))
+    articles = fields.Nested(ArticleSchema(many=True, exclude=['user_id']))

--- a/talelio_backend/shared/utils/pagination.py
+++ b/talelio_backend/shared/utils/pagination.py
@@ -1,0 +1,12 @@
+from math import ceil
+
+
+class Pagination:
+
+    @staticmethod
+    def calculate_offset(page: int, limit: int) -> int:
+        return ((abs(page) - 1) * abs(limit) + 1) - 1
+
+    @staticmethod
+    def total_pages(entries: int, limit: int) -> int:
+        return ceil(entries / limit)

--- a/talelio_backend/shared/utils/slug.py
+++ b/talelio_backend/shared/utils/slug.py
@@ -1,10 +1,5 @@
-from datetime import datetime, timedelta
 from re import findall, sub
 from unicodedata import category, normalize
-
-
-def generate_time_from_now(seconds: int) -> datetime:
-    return datetime.utcnow() + timedelta(seconds=seconds)
 
 
 def generate_slug(text: str) -> str:

--- a/talelio_backend/shared/utils/time.py
+++ b/talelio_backend/shared/utils/time.py
@@ -1,0 +1,5 @@
+from datetime import datetime, timedelta
+
+
+def generate_time_from_now(seconds: int) -> datetime:
+    return datetime.utcnow() + timedelta(seconds=seconds)

--- a/talelio_backend/tests/e2e/conftest.py
+++ b/talelio_backend/tests/e2e/conftest.py
@@ -9,8 +9,7 @@ from talelio_backend.core.db import engine
 from talelio_backend.shared.data.orm import metadata
 from talelio_backend.tests.constants import ACCOUNTS_BASE_URL, ARTICLES_BASE_URL, PROJECTS_BASE_URL
 from talelio_backend.tests.mocks.accounts import talel_login_data, talel_registration_data
-from talelio_backend.tests.mocks.articles import (art_to_engineering_article,
-                                                  private_blockchain_article)
+from talelio_backend.tests.mocks.articles import articles
 from talelio_backend.tests.mocks.projects import talelio_client_project, talelio_server_project
 from talelio_backend.tests.utils import generate_authorization_header
 
@@ -41,7 +40,7 @@ def populate_db_projects(api_server: FlaskClient, authorization_header: Dict[str
 
 @pytest.fixture(scope='class')
 def populate_db_articles(api_server: FlaskClient, authorization_header: Dict[str, str]) -> None:
-    for article in [art_to_engineering_article, private_blockchain_article]:
+    for article in articles:
         api_server.post(ARTICLES_BASE_URL, headers=authorization_header, json=article)
 
 

--- a/talelio_backend/tests/e2e/helpers.py
+++ b/talelio_backend/tests/e2e/helpers.py
@@ -1,6 +1,6 @@
 # pylint: disable=E1101
 from io import BytesIO
-from typing import Dict, Union
+from typing import Dict, Optional, Union
 from unittest.mock import patch
 
 import pytest
@@ -46,8 +46,16 @@ class RequestHelper:
     def get_user_projects_request(self, username: str) -> Response:
         return self.api.get(f'{USERS_BASE_URL}/{username}/projects')  # type: ignore
 
-    def get_user_articles_request(self, username: str) -> Response:
-        return self.api.get(f'{USERS_BASE_URL}/{username}/articles')  # type: ignore
+    def get_user_articles_request(
+            self,
+            username: str,
+            pagination_query_params: Optional[Union[str, None]] = None) -> Response:
+        if pagination_query_params:
+            url = f'{USERS_BASE_URL}/{username}/articles{pagination_query_params}'
+        else:
+            url = f'{USERS_BASE_URL}/{username}/articles'
+
+        return self.api.get(url)  # type: ignore
 
     def create_project_request(self,
                                authorization_header: Dict[str, str],

--- a/talelio_backend/tests/e2e/test_account_api.py
+++ b/talelio_backend/tests/e2e/test_account_api.py
@@ -7,7 +7,7 @@ from flask import json
 from freezegun import freeze_time
 
 from talelio_backend.identity_and_access.authentication import Authentication
-from talelio_backend.shared.utils import generate_time_from_now
+from talelio_backend.shared.utils.time import generate_time_from_now
 from talelio_backend.tests.constants import (EMAIL_BIANCA, EMAIL_TALEL, INITIAL_USER_ID,
                                              INVALID_EMAIL, PASSWORD, USERNAME_BIANCA,
                                              USERNAME_TALEL)

--- a/talelio_backend/tests/e2e/test_article_api.py
+++ b/talelio_backend/tests/e2e/test_article_api.py
@@ -5,7 +5,7 @@ from flask import json
 
 from talelio_backend.shared.utils.slug import generate_slug
 from talelio_backend.tests.e2e.helpers import RequestHelper
-from talelio_backend.tests.mocks.articles import (art_to_engineering_article, camping_gear_article,
+from talelio_backend.tests.mocks.articles import (art_to_engineering_article, hiking_gear_article,
                                                   private_blockchain_article)
 from talelio_backend.tests.mocks.example_markdown import PRIVATE_BLOCKCHAIN_FEATURED_IMAGE_URL
 from talelio_backend.tests.utils import generate_authorization_header
@@ -104,10 +104,10 @@ class TestCreateArticle(RequestHelper):
 class TestGetArticle(RequestHelper):
 
     def test_can_get_article_by_slug(self) -> None:
-        article_slug = generate_slug(camping_gear_article['title'])
+        article_slug = generate_slug(hiking_gear_article['title'])
 
         res = self.get_article_request(article_slug)
         res_data = json.loads(res.data)
 
         assert res.status_code == 200
-        assert res_data['title'] == camping_gear_article['title']
+        assert res_data['title'] == hiking_gear_article['title']

--- a/talelio_backend/tests/e2e/test_article_api.py
+++ b/talelio_backend/tests/e2e/test_article_api.py
@@ -3,7 +3,7 @@ from typing import Dict
 import pytest
 from flask import json
 
-from talelio_backend.shared.utils import generate_slug
+from talelio_backend.shared.utils.slug import generate_slug
 from talelio_backend.tests.e2e.helpers import RequestHelper
 from talelio_backend.tests.mocks.articles import (art_to_engineering_article,
                                                   private_blockchain_article)

--- a/talelio_backend/tests/e2e/test_article_api.py
+++ b/talelio_backend/tests/e2e/test_article_api.py
@@ -5,7 +5,7 @@ from flask import json
 
 from talelio_backend.shared.utils.slug import generate_slug
 from talelio_backend.tests.e2e.helpers import RequestHelper
-from talelio_backend.tests.mocks.articles import (art_to_engineering_article,
+from talelio_backend.tests.mocks.articles import (art_to_engineering_article, camping_gear_article,
                                                   private_blockchain_article)
 from talelio_backend.tests.mocks.example_markdown import PRIVATE_BLOCKCHAIN_FEATURED_IMAGE_URL
 from talelio_backend.tests.utils import generate_authorization_header
@@ -104,10 +104,10 @@ class TestCreateArticle(RequestHelper):
 class TestGetArticle(RequestHelper):
 
     def test_can_get_article_by_slug(self) -> None:
-        article_slug = generate_slug(art_to_engineering_article['title'])
+        article_slug = generate_slug(camping_gear_article['title'])
 
         res = self.get_article_request(article_slug)
         res_data = json.loads(res.data)
 
         assert res.status_code == 200
-        assert res_data['title'] == art_to_engineering_article['title']
+        assert res_data['title'] == camping_gear_article['title']

--- a/talelio_backend/tests/e2e/test_user_api.py
+++ b/talelio_backend/tests/e2e/test_user_api.py
@@ -1,10 +1,11 @@
+from re import findall
+
 import pytest
 from flask import json
 
 from talelio_backend.tests.constants import INVALID_USER, USERNAME_TALEL
 from talelio_backend.tests.e2e.helpers import RequestHelper
-from talelio_backend.tests.mocks.articles import (art_to_engineering_article,
-                                                  private_blockchain_article)
+from talelio_backend.tests.mocks.articles import camping_gear_article, fixed_or_rotary_wing_article
 from talelio_backend.tests.mocks.projects import talelio_client_project, talelio_server_project
 
 
@@ -16,16 +17,52 @@ class TestGetUserArticles(RequestHelper):
         res_data = json.loads(res.data)
 
         assert res.status_code == 200
-        assert len(res_data) == 2
-        assert res_data[0]['title'] == art_to_engineering_article['title']
-        assert res_data[1]['title'] == private_blockchain_article['title']
+        assert res_data['articles'][0]['title'] == camping_gear_article['title']
+        assert res_data['articles'][1]['title'] == fixed_or_rotary_wing_article['title']
 
-    def test_cannot_get_articles_for_non_existing_user(self) -> None:
+    def test_can_get_paginated_user_articles(self) -> None:
+        pagination_query_params = '?page=1&limit=3'
+        res = self.get_user_articles_request(USERNAME_TALEL, pagination_query_params)
+        res_data = json.loads(res.data)
+
+        assert res.status_code == 200
+        assert len(res_data['articles']) == 3
+
+    def test_header_includes_total_articles_count(self) -> None:
+        res = self.get_user_articles_request(USERNAME_TALEL)
+        res_data = json.loads(res.data)
+
+        total_articles_count = res.headers['X-Total-Count']
+        total_articles = len(res_data['articles'])
+
+        assert int(total_articles_count) == total_articles
+
+    def test_header_includes_next_and_prev_pagination(self) -> None:
+        pagination_query_params = '?page=2&limit=2'
+        res = self.get_user_articles_request(USERNAME_TALEL, pagination_query_params)
+
+        # Retrieves pagination query params from URL
+        header_pagination_query_params = findall(r'((?<=articles).*?(?=>))', res.headers['Link'])
+        next_page_query_params = header_pagination_query_params[0]
+        prev_page_query_params = header_pagination_query_params[1]
+
+        assert 'page=3' in next_page_query_params
+        assert 'page=1' in prev_page_query_params
+
+    def test_out_of_range_pagination_returns_empty_response(self) -> None:
+        pagination_query_params = '?page=666&limit=3'
+        res = self.get_user_articles_request(USERNAME_TALEL, pagination_query_params)
+        res_data = json.loads(res.data)
+
+        assert res.status_code == 200
+        assert res_data == {}
+
+    def test_non_existing_user_returns_empty_response(self) -> None:
         res = self.get_user_articles_request(INVALID_USER)
         res_data = json.loads(res.data)
 
-        assert res.status_code == 400
-        assert res_data['error']['message'] == f"User '{INVALID_USER}' does not exist"
+        assert res.status_code == 200
+        assert res_data == {}
 
 
 @pytest.mark.usefixtures('populate_db_account', 'populate_db_projects')

--- a/talelio_backend/tests/e2e/test_user_api.py
+++ b/talelio_backend/tests/e2e/test_user_api.py
@@ -5,7 +5,7 @@ from flask import json
 
 from talelio_backend.tests.constants import INVALID_USER, USERNAME_TALEL
 from talelio_backend.tests.e2e.helpers import RequestHelper
-from talelio_backend.tests.mocks.articles import camping_gear_article, fixed_or_rotary_wing_article
+from talelio_backend.tests.mocks.articles import fixed_or_rotary_wing_article, hiking_gear_article
 from talelio_backend.tests.mocks.projects import talelio_client_project, talelio_server_project
 
 
@@ -17,7 +17,7 @@ class TestGetUserArticles(RequestHelper):
         res_data = json.loads(res.data)
 
         assert res.status_code == 200
-        assert res_data['articles'][0]['title'] == camping_gear_article['title']
+        assert res_data['articles'][0]['title'] == hiking_gear_article['title']
         assert res_data['articles'][1]['title'] == fixed_or_rotary_wing_article['title']
 
     def test_can_get_paginated_user_articles(self) -> None:
@@ -63,6 +63,14 @@ class TestGetUserArticles(RequestHelper):
 
         assert res.status_code == 200
         assert res_data == {}
+
+    def test_cannot_get_articles_with_invalid_pagination_query_params(self) -> None:
+        invalid_pagination_query_params = '?page=one&limit=three'
+        res = self.get_user_articles_request(USERNAME_TALEL, invalid_pagination_query_params)
+        res_data = json.loads(res.data)
+
+        assert res.status_code == 400
+        assert res_data['error']['message'] == 'Expected numeric query parameters'
 
 
 @pytest.mark.usefixtures('populate_db_account', 'populate_db_projects')

--- a/talelio_backend/tests/integration/test_user_services.py
+++ b/talelio_backend/tests/integration/test_user_services.py
@@ -7,7 +7,7 @@ from talelio_backend.app_user.use_cases.authenticate_user import (delete_refresh
                                                                   verify_refresh_token)
 from talelio_backend.core.exceptions import AccountError, TokenError
 from talelio_backend.identity_and_access.authentication import Authentication
-from talelio_backend.shared.utils import generate_time_from_now
+from talelio_backend.shared.utils.time import generate_time_from_now
 from talelio_backend.tests.constants import FAKE_TOKEN, INITIAL_USER_ID, USERNAME_TALEL
 from talelio_backend.tests.integration.helpers import (get_access_token_helper,
                                                        register_account_helper)
@@ -24,11 +24,11 @@ def test_can_get_access_token_for_user() -> None:
 
 
 def test_access_token_expires_after_30_min() -> None:
-    thirtyone_mins_from_now = generate_time_from_now(1860)
+    thirty_one_mins_from_now = generate_time_from_now(1860)
     uow = register_account_helper()
     access_token = get_access_token_helper(uow)
 
-    with freeze_time(thirtyone_mins_from_now):
+    with freeze_time(thirty_one_mins_from_now):
         with pytest.raises(ExpiredSignatureError):
             Authentication.verify_token(access_token)
 

--- a/talelio_backend/tests/mocks/articles.py
+++ b/talelio_backend/tests/mocks/articles.py
@@ -1,4 +1,8 @@
 from talelio_backend.tests.mocks.example_markdown import (ART_TO_ENGINEERING_ARTICLE_BODY,
+                                                          BACKUP_POSTGRES_ARTICLE_BODY,
+                                                          BACKUP_STRATEGY_ARTICLE_BODY,
+                                                          FIXED_OR_ROTARY_WING_ARTICLE_BODY,
+                                                          HIKING_GEAR_ARTICLE_BODY,
                                                           PRIVATE_BLOCKCHAIN_ARTICLE_BODY)
 
 art_to_engineering_article = {
@@ -12,3 +16,32 @@ private_blockchain_article = {
     'body': PRIVATE_BLOCKCHAIN_ARTICLE_BODY,
     'meta_description': 'Setup a test environment with a dockerized blockchain.'
 }
+
+backup_postgres_article = {
+    'title': 'Backing up Dockerized PostgreSQL Db from EC2 to S3',
+    'body': BACKUP_POSTGRES_ARTICLE_BODY,
+    'meta_description': 'Setup Cron Job for automatic database dumps to S3 bucket.'
+}
+
+backup_strategy_article = {
+    'title': 'The Backup Strategy',
+    'body': BACKUP_STRATEGY_ARTICLE_BODY,
+    'meta_description': 'Designing a backup routine.'
+}
+
+fixed_or_rotary_wing_article = {
+    'title': "Fixed or Rotary Wing Pilot's License",
+    'body': FIXED_OR_ROTARY_WING_ARTICLE_BODY,
+    'meta_description': 'Deciding factors for whether to pursuit a PPL(A) or PPL(H).'
+}
+
+hiking_gear_article = {
+    'title': 'Packing Lists for Hiking Trips',
+    'body': HIKING_GEAR_ARTICLE_BODY,
+    'meta_description': 'Items for the outdoors.'
+}
+
+articles = [
+    art_to_engineering_article, private_blockchain_article, backup_postgres_article,
+    backup_strategy_article, fixed_or_rotary_wing_article, hiking_gear_article
+]

--- a/talelio_backend/tests/mocks/example_markdown.py
+++ b/talelio_backend/tests/mocks/example_markdown.py
@@ -39,3 +39,20 @@ PRIVATE_BLOCKCHAIN_ARTICLE_BODY = f'''
 
 ![private blockchain featured image]({PRIVATE_BLOCKCHAIN_FEATURED_IMAGE_URL})
 '''
+
+# TODO: Understand why featured image is required for test to not fail
+BACKUP_POSTGRES_ARTICLE_BODY = '''
+![featured image]()
+'''
+
+BACKUP_STRATEGY_ARTICLE_BODY = '''
+![featured image]()
+'''
+
+FIXED_OR_ROTARY_WING_ARTICLE_BODY = '''
+![featured image]()
+'''
+
+HIKING_GEAR_ARTICLE_BODY = '''
+![featured image]()
+'''

--- a/talelio_backend/tests/unit/test_shared_utils.py
+++ b/talelio_backend/tests/unit/test_shared_utils.py
@@ -1,4 +1,4 @@
-from talelio_backend.shared.utils import generate_slug
+from talelio_backend.shared.utils.slug import generate_slug
 
 
 def test_generates_slug_with_word_characters_only() -> None:


### PR DESCRIPTION
This PR adds pagination support for user articles queries when providing limit and page query parameters. If no query parameters are provided the result defaults to a limit of 10 articles per page.