### PR TITLE
Add health endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
   - [Entity Relationship Diagram](#entity-relationship-diagram)
 - [REST API](#rest-api)
   - [Resources](#resources)
+    - [Health](#health)
     - [Articles](#articles)
 
 # Development
@@ -153,7 +154,36 @@ erDiagram
 
 ## Resources
 
+- [Health](#health)
 - [Articles](#articles)
+
+### Health
+
+| HTTP Method | Description                                     | Resource            | Success Code | Failure Code |
+|-------------|-------------------------------------------------|---------------------|--------------|--------------|
+| GET         | [Backend API health](#get---backend-api-health) | /\<version\>/health | 200          |              |
+
+<details>
+
+<summary>GET - Backend API health</summary>
+<br/>
+
+#### Request
+
+```shell
+curl -X GET \
+https://api.talel.io/v1/health
+```
+
+#### Success Response
+
+```shell
+200: OK
+
+👍
+```
+
+</details>
 
 ### Articles
 

--- a/talelio_backend/core/__init__.py
+++ b/talelio_backend/core/__init__.py
@@ -7,6 +7,7 @@ from talelio_backend.interfaces.api.accounts.account_controller import accounts_
 from talelio_backend.interfaces.api.articles.article_controller import articles_v1
 from talelio_backend.interfaces.api.assets.asset_controller import assets_v1
 from talelio_backend.interfaces.api.errors import error_handlers
+from talelio_backend.interfaces.api.health.health_controller import health_v1
 from talelio_backend.interfaces.api.projects.project_controller import projects_v1
 from talelio_backend.interfaces.api.users.user_controller import users_v1
 from talelio_backend.shared.data.orm import start_mappers
@@ -19,6 +20,7 @@ def create_app() -> Flask:
     app.config.from_object('talelio_backend.config.config.Production' if getenv('ENV') ==
                            'production' else 'talelio_backend.config.config.Development')
 
+    app.register_blueprint(health_v1, url_prefix='/v1/health')
     app.register_blueprint(accounts_v1, url_prefix='/v1/accounts')
     app.register_blueprint(articles_v1, url_prefix='/v1/articles')
     app.register_blueprint(assets_v1, url_prefix='/v1/assets')

--- a/talelio_backend/interfaces/api/health/health_controller.py
+++ b/talelio_backend/interfaces/api/health/health_controller.py
@@ -1,0 +1,10 @@
+from typing import Tuple
+
+from flask import Blueprint
+
+health_v1 = Blueprint('health_v1', __name__)
+
+
+@health_v1.get('')
+def health_endpoint() -> Tuple[str, int]:
+    return '👍', 200


### PR DESCRIPTION
This PR adds a `health` endpoint which is currently only confirming that the backend API is up and running.