### PR TITLE
Enable markdown in HTML

### DIFF
--- a/talelio_backend/app_article/domain/article_model.py
+++ b/talelio_backend/app_article/domain/article_model.py
@@ -19,7 +19,7 @@ class Article:
         self.url = self.__article_base_url + self.slug
 
         self.__markdown = Markdown(
-            extensions=['attr_list', 'tables', 'toc', 'fenced_code',
+            extensions=['attr_list', 'tables', 'toc', 'fenced_code', 'md_in_html',
                         ElementAttributesExtension()])
 
     @property


### PR DESCRIPTION
This PR allows for adding HTML tags while still parsing the markdown inside the html tags.